### PR TITLE
fix: v1.0.1 refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,28 @@
-# ESS-DIVE Reporting Format for Soil Respiration
+# ESS-DIVE Reporting Format for Soil Respiration v1.0.1
 
-This documentation contains guidance for the content and format of ESS-DIVE soil respiration data and metadata reporting format. This reporting format has been developed to meet the needs of the community for a unified reporting format. This initial effort covers the most common variables and provides templates for metadata reporting.
+This documentation contains guidance for the content and format of ESS-DIVE soil respiration data and metadata reporting format. This reporting format has been developed to meet the needs of the researchers for a unified reporting format. This initial effort covers the most common variables and provides templates for metadata reporting.
 
 ---
 
 ## Getting started
 
-### Ready to use the reporting format? [Click here for detailed instructions](https://github.com/ess-dive-community/essdive-soil-respiration/blob/main/instructions.md)
+### Ready to use the reporting format? [Click here for detailed instructions](instructions.md)
+
+## Updates in v1.0.1
+In March 2025, a patch version of the Soil Respiration reporting format was made to improve the overall experience with the associated reporting format documentation. Additionally, the standard reporting format keyword and standard term were added to the instructions.md file.
 
 ## How to contribute 
 
-This reporting format is constantly evolving to meet the needs of the community. To contribute or provide feedback to ESS-DIVE's soil respiration data and metadata reporting format:
+This reporting format is constantly evolving to meet the needs of DOE ESS researchers. To contribute or provide feedback to ESS-DIVE's soil respiration data and metadata reporting format:
 
-1. Go to the [new issue page](https://github.com/ess-dive-community/essdive-soil-respiration/issues/new/choose)
+1. Go to the [new issue page](https://github.com/ess-dive-workspace/essdive-soil-respiration/issues/new/choose)
 2. Choose from one of the provided templates, modeled from the Darwin Core, or create your own
 3. Will we respond with a comment on the issue
 
 Have a question? Contact us at ess-dive-support@lbl.gov. 
 
 ## Copyright information
-This soil respiration data and metadata reporting format is licensed under [CC BY 4.0](https://github.com/ess-dive-community/essdive-soil-respiration/blob/main/LICENSE.md).
+This soil respiration data and metadata reporting format is licensed under [CC BY 4.0](LICENSE.md).
 
 ## Funding and acknowledgements
 

--- a/instructions.md
+++ b/instructions.md
@@ -2,9 +2,9 @@
 
 A data package containing soil respiration data must include, at a minimum: 
 
-1. Assemble the data table by downloading and filling in the [data template](templates/data_reportingformat_template.xlsx). These serve as a guide for how the table should be structured. See our [data format guide](/data_reporting_format_guide.md) for descriptions and instructions for each data field.
+1. Assemble the data table by downloading and filling in the data template in [XLSX](templates/data_reportingformat_template.xlsx) or [CSV](templates/data_reportingformat_template.csv) format. These serve as a guide for how the table should be structured. See our [data format guide](/data_reporting_format_guide.md) for descriptions and instructions for each data field.
 
-2. Assemble the metadata table by downloading and filling in the [chamber-level metadata template](templates/chammetadata_reportingformat_template.xlsx). See our [chamber-level metadata format guide](chamber_level_metadata_guide.md) for descriptions and instructions for each field.
+2. Assemble the metadata table by downloading and filling in the chamber-level metadata template in [XLSX](templates/chammetadata_reportingformat_template.xlsx) or [CSV](templates/chammetadata_reportingformat_template.csv) formats. See our [chamber-level metadata format guide](chamber_level_metadata_guide.md) for descriptions and instructions for each field.
 
 3. Ensure that all _required_ data types are included for each table (see required data tables below) and save each file as a `.csv`
 

--- a/instructions.md
+++ b/instructions.md
@@ -2,11 +2,13 @@
 
 A data package containing soil respiration data must include, at a minimum: 
 
-1. Assemble the data table by downloading and filling in the [data template](https://github.com/ess-dive-community/essdive-soil-respiration/blob/main/templates/data_reportingformat_template.xlsx). These serve as a guide for how the table should be structured. See our [data format guide](https://github.com/ess-dive-community/essdive-soil-respiration/blob/main/data_reporting_format_guide.md) for descriptions and instructions for each data field.
+1. Assemble the data table by downloading and filling in the [data template](templates/data_reportingformat_template.xlsx). These serve as a guide for how the table should be structured. See our [data format guide](/data_reporting_format_guide.md) for descriptions and instructions for each data field.
 
-2. Assemble the metadata table by downloading and filling in the [chamber-level metadata template](https://github.com/ess-dive-community/essdive-soil-respiration/blob/main/templates/chammetadata_reportingformat_template.xlsx). See our [chamber-level metadata format guide](https://github.com/ess-dive-community/essdive-soil-respiration/blob/main/chamber_level_metadata_guide.md) for descriptions and instructions for each field.
+2. Assemble the metadata table by downloading and filling in the [chamber-level metadata template](templates/chammetadata_reportingformat_template.xlsx). See our [chamber-level metadata format guide](chamber_level_metadata_guide.md) for descriptions and instructions for each field.
 
-4. Ensure that all _required_ data types are included for each table (see required data tables below) and save each file as a `.csv` 
+3. Ensure that all _required_ data types are included for each table (see required data tables below) and save each file as a `.csv`
+
+4. Within the FLMD file, the [standard](https://github.com/ess-dive-workspace/essdive-file-level-metadata/blob/main/flmd_quick_guide.md#standard) for each soil respiration reporting format related file should be **ESS-DIVE Soil Respiration v1**. If submitting your dataset to ESS-DIVE, include the keyword **ESS-DIVE Soil Respiration Reporting Format** in the package-level metadata. 
 
 | Required Data Variables                                                                        |
 |:-----------------------------------------------------------------------------------------------|
@@ -26,8 +28,8 @@ A data package containing soil respiration data must include, at a minimum:
 
 ## Additional information
 
-Defined variables should be used where available. For **variables not yet covered** by this reporting format documentation, data contributors should use machine readable variable names that are in common use and follow ESS-DIVE data dictionary format guidelines as described [here](https://github.com/ess-dive-community/essdive-file-level-metadata/blob/master/CSV_dd/CSV_dd_instructions.md). 
+Defined variables should be used where available. For **variables not yet covered** by this reporting format documentation, data contributors should use machine readable variable names that are in common use and follow ESS-DIVE data dictionary format guidelines as described [here](https://github.com/ess-dive-workspace/essdive-file-level-metadata/blob/master/CSV_dd/CSV_dd_instructions.md). 
 
 Inclusion of additional related datasets with soil respiration data is encouraged. This can include measurements made inline, such as soil moisture or temperature, or subsequent analysis of chemical composition or physical properties. Related data should be linked by using common sample identifiers. 
 
-We will continue to work with the ESS community to improve data and metadata reporting formats for soil respiration data. Please [contribute](contribute.md) by submitting issues, using our issue templates, or contact ess-dive-support@lbl.gov to provide any feedback on the process of formatting data or specific metadata fields.
+We will continue to work with the ESS researchers to improve data and metadata reporting formats for soil respiration data. Please [contribute](contribute.md) by submitting issues, using our issue templates, or contact ess-dive-support@lbl.gov to provide any feedback on the process of formatting data or specific metadata fields.

--- a/templates/README.md
+++ b/templates/README.md
@@ -3,7 +3,7 @@
 Feel free to download and populate either version of the template as they both contain the same information. The `.xlsx` version simply highlights the required variables in blue and orange (as shown in the photos below), making them a bit easier to identify. **Please save your template as a CSV.**
 
 #### Data Table Template
-![](https://github.com/ess-dive-community/essdive-soil-respiration/blob/main/templates/data_template.png)
+![](https://github.com/ess-dive-workspace/essdive-soil-respiration/blob/main/templates/data_template.png)
 
 #### Chamber-level Metadata Template
-![](https://github.com/ess-dive-community/essdive-soil-respiration/blob/main/templates/chammetadata_template.png)
+![](https://github.com/ess-dive-workspace/essdive-soil-respiration/blob/main/templates/chammetadata_template.png)


### PR DESCRIPTION
In March 2025, a patch version of the Soil Respiration reporting format was made to improve the overall experience with the associated reporting format documentation. Additionally, the standard reporting format keyword and standard term were added to the instructions.md file. The following files were updated:

- ReadMe.md
- instructions.md
- templates/ReadMe.md